### PR TITLE
Remove underscores from function name ST_Line_Interpolate_Point()

### DIFF
--- a/rivergis/hecobjects.py
+++ b/rivergis/hecobjects.py
@@ -836,7 +836,7 @@ WITH inter_xs_dump AS
         "XsecID",
         "N_Value",
         "LUCode",
-        ST_Line_Interpolate_Point(inter_xs_dump.geom, 0.00005)::geometry(POINT, {1}) AS geom
+        ST_LineInterpolatePoint(inter_xs_dump.geom, 0.00005)::geometry(POINT, {1}) AS geom
     FROM
         inter_xs_dump),
     tmpman AS


### PR DESCRIPTION
New versions of PostGIS have changed the name of the function:` ST_Line_Interpolate_Point() ` to `ST_LineInterpolatePoint()`  since version 2.1.0:
  [changelog 2.32](https://postgis.net/docs/release_notes.html#idm42286).
The attached PR is a trivial edit at line 829 of hecobjects.py. 

HTH